### PR TITLE
Set data type for `NULL` params

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,29 @@ Performance-wise this syntax is slightly slower to prepare the statement and a t
 
 Importantly, this method is not based on "artificial" string replacement. In fact, the statement is prepared just as if it was the default syntax.
 
+#### Typed params
+
+In the case, the parameter type has to be explicitly stated, there's a wrapper class - `Parameter` that will help provide explicit type information.
+
+```kotlin
+val param = Parameter(param, String::class.java)
+queryOf("""select id, name 
+    from members 
+    where ? is null or ? = name""", 
+    param, param)
+``` 
+
+or also with the helper function `param`
+
+```kotlin
+queryOf("""select id, name 
+    from members 
+    where ? is null or ? = name""", 
+    null.param<String>(), null.param<String>())
+```
+
+This can be useful in situations similar to one described [here](https://www.postgresql.org/message-id/6ekbd7dm4d6su5b9i4hsf92ibv4j76n51f@4ax.com).
+
 #### Working with Large Dataset
 
 `#forEach` allows you to make some side-effect in iterations. This API is useful for handling large `ResultSet`.

--- a/src/main/kotlin/kotliquery/Parameter.kt
+++ b/src/main/kotlin/kotliquery/Parameter.kt
@@ -1,0 +1,29 @@
+package kotliquery
+
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.net.URL
+import java.sql.Types
+import java.time.*
+
+open class Parameter<out T>(val value: T?,
+                            val type: Class<out T>)
+
+fun <T> Parameter<T>.sqlType() = when (type) {
+    String::class.java, URL::class.java -> Types.VARCHAR
+    Int::class.java, Long::class.java, Short::class.java,
+    Byte::class.java, BigInteger::class.java -> Types.NUMERIC
+    Double::class.java, BigDecimal::class.java -> Types.DOUBLE
+    Float::class.java -> Types.FLOAT
+    java.sql.Date::class.java, java.util.Date::class.java, ZonedDateTime::class.java, OffsetDateTime::class.java,
+    Instant::class.java, LocalDateTime::class.java, org.joda.time.DateTime::class.java, org.joda.time.LocalDateTime::class.java,
+    java.sql.Timestamp::class.java -> Types.TIMESTAMP
+    java.sql.Time::class.java, LocalTime::class.java -> Types.TIME
+    LocalDate::class.java -> Types.DATE
+    else -> Types.OTHER
+}
+
+inline fun <reified T> T?.param(): Parameter<T> = when (this) {
+    is Parameter<*> -> Parameter(this.value as T?, this.type as Class<T>)
+    else -> Parameter(this, T::class.java)
+}

--- a/src/main/kotlin/kotliquery/Session.kt
+++ b/src/main/kotlin/kotliquery/Session.kt
@@ -8,6 +8,7 @@ import java.net.URL
 import java.sql.PreparedStatement
 import java.sql.Statement
 import java.sql.Timestamp
+import java.sql.Types
 import java.time.*
 import java.util.*
 
@@ -29,7 +30,7 @@ open class Session(
 
     private fun PreparedStatement.setParam(idx: Int, v: Any?) {
         if (v == null) {
-            this.setObject(idx, null)
+            this.setNull(idx, Types.VARCHAR)
         } else {
             when (v) {
                 is String -> this.setString(idx, v)
@@ -66,7 +67,7 @@ open class Session(
     }
 
     fun populateParams(query: Query, stmt: PreparedStatement): PreparedStatement {
-        if(query.replacementMap.isNotEmpty()) {
+        if (query.replacementMap.isNotEmpty()) {
             query.replacementMap.forEach { paramName, occurrences ->
                 occurrences.forEach {
                     stmt.setParam(it + 1, query.paramMap[paramName])
@@ -144,7 +145,7 @@ open class Session(
         }
     }
 
-    fun updateAndReturnGeneratedKey (query: Query): Long? {
+    fun updateAndReturnGeneratedKey(query: Query): Long? {
         warningForTransactionMode()
         return using(createPreparedStatement(query)) { stmt ->
             if (stmt.executeUpdate() > 0) {
@@ -163,6 +164,7 @@ open class Session(
     fun run(action: UpdateQueryAction): Int {
         return action.runWithSession(this)
     }
+
     fun run(action: UpdateAndReturnGeneratedKeyQueryAction): Long? {
         return action.runWithSession(this)
     }
@@ -183,7 +185,7 @@ open class Session(
             val result: A = operation.invoke(tx)
             connection.commit()
             return result
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             connection.rollback()
             throw e
         } finally {

--- a/src/test/kotlin/kotliquery/NamedParamTest.kt
+++ b/src/test/kotlin/kotliquery/NamedParamTest.kt
@@ -47,23 +47,4 @@ class NamedParamTest {
             }
         }
     }
-
-    fun describe(description: String, tests: () -> Unit) {
-        println(description)
-
-        tests()
-    }
-
-    fun withQueries(vararg stmts: String, assertions: (Query) -> Unit) {
-        stmts.forEach {
-            val query = queryOf(it)
-
-            assertions(query)
-        }
-    }
-
-}
-
-fun String.normalizeSpaces(): String {
-    return Regex("[ \\n\\t]+").replace(this, " ")
 }

--- a/src/test/kotlin/kotliquery/UsageTest.kt
+++ b/src/test/kotlin/kotliquery/UsageTest.kt
@@ -241,6 +241,17 @@ create table members (
         }
     }
 
+    @Test
+    fun nullParamsJdbcHandling() {
+        // this test could fail for PostgreSQL
+        using(borrowConnection()) { conn ->
+            val session = Session(Connection(conn, driverName))
+
+            val id = session.single(queryOf("select 1 from dual where ? is null", null)) { row -> row.int(1) }
+            assertEquals(1, id)
+        }
+    }
+
     fun withPreparedStmt(query: Query, closure: (PreparedStatement) -> Unit) {
         using(borrowConnection()) { conn ->
             val session = Session(Connection(conn, driverName))
@@ -252,7 +263,7 @@ create table members (
     }
 
     fun String.extractQueryFromPreparedStmt(): String {
-        return this.split(": ", limit = 2)[1].normalizeSpaces()
+        return this.replace(Regex("^.*?: "), "").normalizeSpaces()
     }
 
 }

--- a/src/test/kotlin/kotliquery/UsageTest.kt
+++ b/src/test/kotlin/kotliquery/UsageTest.kt
@@ -3,6 +3,7 @@ package kotliquery
 import org.junit.Test
 import java.sql.DriverManager
 import java.sql.PreparedStatement
+import java.sql.Timestamp
 import java.time.ZonedDateTime
 import java.util.*
 import kotlin.test.assertEquals
@@ -93,8 +94,6 @@ create table members (
             assertEquals(2, createdID2)
         }
     }
-
-
 
 
     @Test
@@ -247,8 +246,36 @@ create table members (
         using(borrowConnection()) { conn ->
             val session = Session(Connection(conn, driverName))
 
-            val id = session.single(queryOf("select 1 from dual where ? is null", null)) { row -> row.int(1) }
-            assertEquals(1, id)
+            session.run(queryOf("drop table if exists members").asExecute)
+            session.run(queryOf("""
+create table members (
+  id serial not null primary key
+)
+        """).asExecute)
+            session.run(queryOf("insert into members(id) values (1)").asUpdate)
+
+            describe("typed param with value") {
+                assertEquals(1, session.single(queryOf("select 1 from members where ? = id", 1)) { row -> row.int(1) })
+            }
+
+            describe("typed null params") {
+                assertEquals(1, session.single(queryOf("select 1 from members where ? is null", null.param<String>())) { row -> row.int(1) })
+            }
+
+            describe("typed null comparison") {
+                assertEquals(1,
+                        session.single(queryOf("select 1 from members where ? is null or ? = now()",
+                                null.param<String>(),
+                                null.param<Timestamp>())) { row -> row.int(1) }
+                )
+            }
+
+            describe("select null") {
+                val param: String? = null
+                assertNull(session.single(queryOf("select ? from members", Parameter(param, String::class.java))) { row -> row.stringOrNull(1) })
+            }
+
+            session.run(queryOf("drop table if exists members").asExecute)
         }
     }
 

--- a/src/test/kotlin/kotliquery/test-package.kt
+++ b/src/test/kotlin/kotliquery/test-package.kt
@@ -1,0 +1,20 @@
+package kotliquery
+
+
+fun describe(description: String, tests: () -> Unit) {
+    println(description)
+
+    tests()
+}
+
+fun withQueries(vararg stmts: String, assertions: (Query) -> Unit) {
+    stmts.forEach {
+        val query = queryOf(it)
+
+        assertions(query)
+    }
+}
+
+fun String.normalizeSpaces(): String {
+    return Regex("[ \\n\\t]+").replace(this, " ")
+}


### PR DESCRIPTION
In relation to issue #14.

The tests will always succeed with H2, but when executed with Postgres, the test `nullParamsJdbcHandling` should testify that the issue is closed.

When/If this PR is merged, please create a new release.