### PR TITLE
Avoid double colons when searching for named parameters

### DIFF
--- a/src/main/kotlin/kotliquery/Query.kt
+++ b/src/main/kotlin/kotliquery/Query.kt
@@ -43,6 +43,6 @@ data class Query(
     }
 
     companion object {
-        private val regex = Regex(""":\w+""")
+        private val regex = Regex("""(?<!:):(?!:)\w+""")
     }
 }

--- a/src/test/kotlin/kotliquery/NamedParamTest.kt
+++ b/src/test/kotlin/kotliquery/NamedParamTest.kt
@@ -2,6 +2,7 @@ package kotliquery
 
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class NamedParamTest {
 
@@ -44,6 +45,14 @@ class NamedParamTest {
                         "param2" to listOf(1, 2),
                         "param3" to listOf(3, 4)
                 ), query.replacementMap)
+            }
+        }
+
+        describe("do not extract anything") {
+            withQueries(
+                """SELECT * FROM table t WHERE param1 = '2018-01-01'::DATE"""
+            ) { query ->
+                assertTrue(query.replacementMap.isEmpty())
             }
         }
     }


### PR DESCRIPTION
Hi,

double colons are used e.g., in PostgreSQL to cast variables; the previous regex matched those as well, and tried to find names of variables.
This patch does not match double colons but only single colons.

Let me know if you need anything else.