### PR TITLE
Support three types of batched jdbc statements.

### DIFF
--- a/src/main/kotlin/kotliquery/Query.kt
+++ b/src/main/kotlin/kotliquery/Query.kt
@@ -16,12 +16,6 @@ data class Query(
     val replacementMap: Map<String, List<Int>> = extractNamedParamsIndexed(statement)
     val cleanStatement: String = replaceNamedParams(statement)
 
-    private fun extractNamedParamsIndexed(stmt: String): Map<String, List<Int>> {
-        return regex.findAll(stmt).mapIndexed { index, group ->
-            Pair(group, index)
-        }.groupBy({ it.first.value.substring(1) }, { it.second })
-    }
-
     private fun replaceNamedParams(stmt: String): String {
         return regex.replace(stmt, "?")
     }
@@ -44,5 +38,12 @@ data class Query(
 
     companion object {
         private val regex = Regex("""(?<!:):(?!:)\w+""")
+
+        internal fun extractNamedParamsIndexed(stmt: String): Map<String, List<Int>> {
+            return regex.findAll(stmt).mapIndexed { index, group ->
+                Pair(group, index)
+            }.groupBy({ it.first.value.substring(1) }, { it.second })
+        }
+
     }
 }

--- a/src/main/kotlin/kotliquery/Session.kt
+++ b/src/main/kotlin/kotliquery/Session.kt
@@ -157,10 +157,10 @@ open class Session(
         return rows(query, extractor).toList()
     }
 
-    fun batchManyStatements(statements: Collection<String>): List<Int> {
+    fun batchRawStatements(statements: Collection<String>): List<Int> {
         warningForTransactionMode()
         return using(connection.underlying.createStatement()) { st ->
-            statements.forEach{
+            statements.forEach {
                 st.addBatch(it)
             }
             st.executeBatch().toList()

--- a/src/main/kotlin/kotliquery/Session.kt
+++ b/src/main/kotlin/kotliquery/Session.kt
@@ -115,6 +115,31 @@ open class Session(
         }
     }
 
+    private fun rowsBatched(statement: String, params: Collection<Collection<Any>>, namedParams: Collection<Map<String, Any?>>): List<Int> {
+        return using(connection.underlying.prepareStatement(Query(statement).cleanStatement)) { stmt ->
+
+            if (namedParams.isNotEmpty()) {
+                val extracted = Query.extractNamedParamsIndexed(statement)
+                namedParams.forEach { paramRow ->
+                    extracted.forEach { paramName, occurrences ->
+                        occurrences.forEach {
+                            stmt.setTypedParam(it + 1, paramRow[paramName].param())
+                        }
+                    }
+                    stmt.addBatch()
+                }
+            } else {
+                params.forEach { paramsRow ->
+                    paramsRow.forEachIndexed { idx, value ->
+                        stmt.setTypedParam(idx + 1, value.param())
+                    }
+                    stmt.addBatch()
+                }
+            }
+            stmt.executeBatch().toList()
+        }
+    }
+
     private fun warningForTransactionMode(): Unit {
         if (transactional) {
             logger.warn("Use TransactionalSession instead. The `tx` of `session.transaction { tx -> ... }`")
@@ -130,6 +155,26 @@ open class Session(
     fun <A> list(query: Query, extractor: (Row) -> A?): List<A> {
         warningForTransactionMode()
         return rows(query, extractor).toList()
+    }
+
+    fun batchManyStatements(statements: List<String>): List<Int> {
+        warningForTransactionMode()
+        return using(connection.underlying.createStatement()) { st ->
+            statements.forEach{
+                st.addBatch(it)
+            }
+            st.executeBatch().toList()
+        }
+    }
+
+    fun batchPreparedNamedStatement(statement: String, params: Collection<Map<String, Any?>>): List<Int> {
+        warningForTransactionMode()
+        return rowsBatched(statement, emptyList(), params)
+    }
+
+    fun batchPreparedStatement(statement: String, params: Collection<Collection<Any>>): List<Int> {
+        warningForTransactionMode()
+        return rowsBatched(statement, params, emptyList())
     }
 
     fun forEach(query: Query, operator: (Row) -> Unit): Unit {

--- a/src/main/kotlin/kotliquery/Session.kt
+++ b/src/main/kotlin/kotliquery/Session.kt
@@ -115,7 +115,7 @@ open class Session(
         }
     }
 
-    private fun rowsBatched(statement: String, params: Collection<Collection<Any>>, namedParams: Collection<Map<String, Any?>>): List<Int> {
+    private fun rowsBatched(statement: String, params: Collection<Collection<Any?>>, namedParams: Collection<Map<String, Any?>>): List<Int> {
         return using(connection.underlying.prepareStatement(Query(statement).cleanStatement)) { stmt ->
 
             if (namedParams.isNotEmpty()) {
@@ -157,7 +157,7 @@ open class Session(
         return rows(query, extractor).toList()
     }
 
-    fun batchManyStatements(statements: List<String>): List<Int> {
+    fun batchManyStatements(statements: Collection<String>): List<Int> {
         warningForTransactionMode()
         return using(connection.underlying.createStatement()) { st ->
             statements.forEach{
@@ -172,7 +172,7 @@ open class Session(
         return rowsBatched(statement, emptyList(), params)
     }
 
-    fun batchPreparedStatement(statement: String, params: Collection<Collection<Any>>): List<Int> {
+    fun batchPreparedStatement(statement: String, params: Collection<Collection<Any?>>): List<Int> {
         warningForTransactionMode()
         return rowsBatched(statement, params, emptyList())
     }

--- a/src/test/kotlin/kotliquery/UsageTest.kt
+++ b/src/test/kotlin/kotliquery/UsageTest.kt
@@ -291,7 +291,7 @@ create table members (
             session.execute(queryOf("drop table members if exists"))
             session.execute(queryOf(createTableStmt))
 
-            val res = session.batchManyStatements(listOf(
+            val res = session.batchRawStatements(listOf(
                     "insert into members(id, created_at) values (1, now())",
                     "insert into members(id, created_at) values (2, now())",
                     "insert into members(id, created_at) values (3, now())"


### PR DESCRIPTION
This is just a suggestion, I am fine with any changes you propose.

JDBC batching is kind of awkward imo, and it does not fit very good with kotliquery (either). So after trying a bit, I decided that very specific api calls may be best, i.e. not relying on Query at all. I think this will fit quite well with what we need in our project.
