### PR TITLE
Leave kotlin-test dependency as testCompile instead of compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,10 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'joda-time:joda-time:2.10'
     provided 'com.zaxxer:HikariCP:3.2.0'
+    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testCompile 'com.h2database:h2:1.4.197'
     testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
The IDE was suggesting me imports from kotlin-test, which we were not currently using in the project. After checking the dependency tree, I saw that kotliquery was the one bringing the dependency.
I guess this is a mistake and the dependency should be only for the tests in Kotliquery. Hence, this PR :)