### PR TITLE
Modify named parameter extraction regex

### DIFF
--- a/src/main/kotlin/kotliquery/Query.kt
+++ b/src/main/kotlin/kotliquery/Query.kt
@@ -37,7 +37,7 @@ data class Query(
     }
 
     companion object {
-        private val regex = Regex("""(?<!:):(?!:)\w+""")
+        private val regex = Regex("""(?<!:):(?!:)[a-zA-Z]\w+""")
 
         internal fun extractNamedParamsIndexed(stmt: String): Map<String, List<Int>> {
             return regex.findAll(stmt).mapIndexed { index, group ->

--- a/src/test/kotlin/kotliquery/NamedParamTest.kt
+++ b/src/test/kotlin/kotliquery/NamedParamTest.kt
@@ -48,6 +48,14 @@ class NamedParamTest {
             }
         }
 
+        describe("do not extract from timestamp minutes and seconds") {
+            withQueries(
+                    """SELECT * FROM table t WHERE param1 = '2018-01-01 00:00:00'"""
+            ) { query ->
+                assertTrue(query.replacementMap.isEmpty())
+            }
+        }
+
         describe("do not extract anything") {
             withQueries(
                 """SELECT * FROM table t WHERE param1 = '2018-01-01'::DATE"""


### PR DESCRIPTION
I am opening this PR as suggestion to fixing the issue that I reported in #36 

In order to prevent named param detection when using timestamp strings
we are disallowing named parameters using a digit as first character in
the name.

I hope you find this solution appropriate as I really enjoy your lib and would like to continue using it. 🙏  If we can't fix this I have to revert to Spring JDBC to have native query support with named parameters. 