### PR TITLE
Add shorthand sessionOf and transactionOf

### DIFF
--- a/src/main/kotlin/kotliquery/package.kt
+++ b/src/main/kotlin/kotliquery/package.kt
@@ -26,6 +26,18 @@ fun sessionOf(dataSource: DataSource, returnGeneratedKey: Boolean = false): Sess
     return Session(Connection(dataSource.connection), returnGeneratedKey)
 }
 
+fun <T> sessionOf(dataSource: DataSource, returnGeneratedKey: Boolean = false, operation: (Session) -> T): T {
+    return using(sessionOf(dataSource, returnGeneratedKey)) {
+        operation(it)
+    }
+}
+
+fun <T> transactionOf(dataSource: DataSource, returnGeneratedKey: Boolean = false, operation: (TransactionalSession) -> T): T {
+    return using(sessionOf(dataSource, returnGeneratedKey)) {
+        it.transaction(operation)
+    }
+}
+
 fun <A : AutoCloseable, R> using(closeable: A?, f: (A) -> R): R {
     return LoanPattern.using(closeable, f)
 }

--- a/src/test/kotlin/kotliquery/UsageTest.kt
+++ b/src/test/kotlin/kotliquery/UsageTest.kt
@@ -162,7 +162,7 @@ create table members (
     fun testHikariCPUsage() {
         HikariCP.default("jdbc:h2:mem:hello", "user", "pass")
 
-        using(sessionOf(HikariCP.dataSource())) { session ->
+        sessionOf(HikariCP.dataSource()) { session ->
 
             session.run(queryOf("drop table members if exists").asExecute)
             session.run(queryOf(createTableStmt).asExecute)


### PR DESCRIPTION
Additional shorthand `sessionOf` that doesn't need to be wrapped with `using`. 

Plus `transactionOf` as often times you need a transaction for the whole session and with this you don't need to nest transaction block in session block.

With this I believe it cannot get any better with the amount of control and readability it offers:

```kotlin
val ds : DataSource by instance() // kodein

sessionOf(ds) { session ->
  // ...
}

transactionOf(ds) { tx ->
  // ...
}
```