### PR TITLE
Make Session.transaction inline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation "com.h2database:h2:2.1.210"
     testImplementation "junit:junit:4.13.2"
     testImplementation "ch.qos.logback:logback-classic:1.2.10"
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
 }
 
 mavenPublish {

--- a/src/main/kotlin/kotliquery/Session.kt
+++ b/src/main/kotlin/kotliquery/Session.kt
@@ -303,7 +303,7 @@ open class Session(
         return action.runWithSession(this)
     }
 
-    fun <A> transaction(operation: (TransactionalSession) -> A): A {
+    inline fun <A> transaction(operation: (TransactionalSession) -> A): A {
         try {
             connection.begin()
             transactional = true


### PR DESCRIPTION
By marking it as an inline function, it becomes possible to use `transaction` from a coroutine context, without having to any additional sit-ups to make it work.

For example, this code does not work now, but works fine with this patch applied:

```kotlin
withTimeout(1000) {
    async {
        sessionOf(dataSource).use { dbSess ->
            dbSess.transaction { txSess ->
                delay(1000)
                // Without inline, fails with: 
                //     Suspension functions can be called only within coroutine body
                // Works fine when `transaction` is inline
            }
        }
    }
}
```

As far as I can tell, marking `transaction` as inline has no negative side effects for the current uses, and should be fully backwards compatible :)