### PR TITLE
Updated joda-time to newest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.slf4j:slf4j-api:1.7.36"
-    implementation "joda-time:joda-time:2.11.0"
+    implementation "joda-time:joda-time:2.12.7"
     // TODO: upgrade to 5+ when dropping Java 8 supports
     implementation "com.zaxxer:HikariCP:4.0.3"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"


### PR DESCRIPTION
To avoid CVE-2024-23080

The release notes is availlable at https://www.joda.org/joda-time/changes-report.html#a2.12.0 , looks like small, nice changes to me

Not that the reported CVE itself looks scary at all, it's probably a false positive, but this dependency update sounds like a good idea anyway, and an easy way to get rid of the false positive in scan tools is to upgrade past it.